### PR TITLE
fix detection of own app path

### DIFF
--- a/helper/helper.php
+++ b/helper/helper.php
@@ -54,7 +54,7 @@ class Helper {
 	}
 
 	public static function getOwnAppPath() {
-		return getcwd() . '/apps/' . Settings::APP_ID . '/';
+		return realpath(__DIR__ . '/..') . '/';
 	}
 
 	public static function notifyIfAppNotSetUp() {


### PR DESCRIPTION
oC allows multiple app directories to be configured which means the app isn't always stored in `/owncloud/apps/`, going from the location of the current file is more reliable
