### PR TITLE
Support standalone mode that renders template without header/footer.

### DIFF
--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -49,7 +49,11 @@ class PageController extends Controller {
 		$params = [
 			'is_guest' => ($this->userid === null),
 		];
-		$response = new TemplateResponse(Settings::APP_ID, 'webrtc', $params, ($this->userid === null ? 'empty' : 'user'));
+		$renderAs = ($this->userid === null ? 'empty' : 'user');
+		if ($this->request->getParam('standalone')) {
+			$renderAs = 'empty';
+		}
+		$response = new TemplateResponse(Settings::APP_ID, 'webrtc', $params, $renderAs);
 
 		// Allow to embed iframes
 		$csp = new ContentSecurityPolicy();


### PR DESCRIPTION
Can be activated by adding a non-empty query parameter `standalone`.